### PR TITLE
ci: publish only on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   publish:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,4 +28,4 @@ jobs:
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create v$version $filepath --generate-notes
+        run: gh release create v$version $filepath --generate-notes --verify-tag


### PR DESCRIPTION
simplify the release process, taking a cue from the ci documentation.

see: https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions